### PR TITLE
Adds support of io.paketo.stacks.tiny

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -26,6 +26,9 @@ id = "io.buildpacks.stacks.bionic"
 [[stacks]]
 id = "org.cloudfoundry.stacks.cflinuxfs3"
 
+[[stacks]]
+id = "io.paketo.stacks.tiny"
+
 [metadata]
 pre-package   = "scripts/build.sh"
 include-files = [

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/buildpacks/libcnb v1.12.1
+	github.com/mattn/go-shellwords v1.0.10
 	github.com/onsi/gomega v1.10.1
 	github.com/paketo-buildpacks/libpak v1.34.0
 	github.com/sclevine/spec v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-shellwords v1.0.10 h1:Y7Xqm8piKOO3v10Thp7Z36h4FYFjt5xB//6XvOrs2Gw=
+github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=

--- a/procfile/build.go
+++ b/procfile/build.go
@@ -25,6 +25,8 @@ import (
 	"github.com/paketo-buildpacks/libpak/bard"
 )
 
+const tinyStackID = "io.paketo.stacks.tiny"
+
 type Build struct {
 	Logger bard.Logger
 }
@@ -42,7 +44,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	for k, v := range e.Metadata {
-		result.Processes = append(result.Processes, libcnb.Process{Type: k, Command: v.(string)})
+		result.Processes = append(result.Processes, libcnb.Process{Type: k, Command: v.(string), Direct: context.StackID == tinyStackID})
 	}
 
 	sort.Slice(result.Processes, func(i int, j int) bool {

--- a/procfile/build_test.go
+++ b/procfile/build_test.go
@@ -44,7 +44,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Name: "procfile",
 					Metadata: map[string]interface{}{
 						"test-type-1": "test-command-1",
-						"test-type-2": "test-command-2",
+						"test-type-2": "test-command-2 argument",
 					},
 				},
 			},
@@ -52,8 +52,16 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		result := libcnb.NewBuildResult()
 		result.Processes = append(result.Processes,
-			libcnb.Process{Type: "test-type-1", Command: "test-command-1", Direct: false},
-			libcnb.Process{Type: "test-type-2", Command: "test-command-2", Direct: false},
+			libcnb.Process{
+				Type:    "test-type-1",
+				Command: "test-command-1",
+				Direct:  false,
+			},
+			libcnb.Process{
+				Type:    "test-type-2",
+				Command: "test-command-2 argument",
+				Direct:  false,
+			},
 		)
 
 		Expect(build.Build(ctx)).To(Equal(result))
@@ -66,7 +74,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Name: "procfile",
 					Metadata: map[string]interface{}{
 						"test-type-1": "test-command-1",
-						"test-type-2": "test-command-2",
+						"test-type-2": "test-command-2 argument",
 					},
 				},
 			},
@@ -76,8 +84,17 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		result := libcnb.NewBuildResult()
 		result.Processes = append(result.Processes,
-			libcnb.Process{Type: "test-type-1", Command: "test-command-1", Direct: true},
-			libcnb.Process{Type: "test-type-2", Command: "test-command-2", Direct: true},
+			libcnb.Process{
+				Type:    "test-type-1",
+				Command: "test-command-1",
+				Direct:  true,
+			},
+			libcnb.Process{
+				Type:      "test-type-2",
+				Command:   "test-command-2",
+				Arguments: []string{"argument"},
+				Direct:    true,
+			},
 		)
 
 		Expect(build.Build(ctx)).To(Equal(result))

--- a/procfile/build_test.go
+++ b/procfile/build_test.go
@@ -52,8 +52,32 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		result := libcnb.NewBuildResult()
 		result.Processes = append(result.Processes,
-			libcnb.Process{Type: "test-type-1", Command: "test-command-1"},
-			libcnb.Process{Type: "test-type-2", Command: "test-command-2"},
+			libcnb.Process{Type: "test-type-1", Command: "test-command-1", Direct: false},
+			libcnb.Process{Type: "test-type-2", Command: "test-command-2", Direct: false},
+		)
+
+		Expect(build.Build(ctx)).To(Equal(result))
+	})
+
+	it("adds metadata to result", func() {
+		ctx.Plan = libcnb.BuildpackPlan{
+			Entries: []libcnb.BuildpackPlanEntry{
+				{
+					Name: "procfile",
+					Metadata: map[string]interface{}{
+						"test-type-1": "test-command-1",
+						"test-type-2": "test-command-2",
+					},
+				},
+			},
+		}
+
+		ctx.StackID = "io.paketo.stacks.tiny"
+
+		result := libcnb.NewBuildResult()
+		result.Processes = append(result.Processes,
+			libcnb.Process{Type: "test-type-1", Command: "test-command-1", Direct: true},
+			libcnb.Process{Type: "test-type-2", Command: "test-command-2", Direct: true},
 		)
 
 		Expect(build.Build(ctx)).To(Equal(result))


### PR DESCRIPTION
- This will allow for the use of the Procfile CNB on the
io.paketo.stacks.tiny
- Sets Direct parameter on process if it is running on
io.paketo.stacks.tiny