### PR TITLE
Adds release dispatch workflow

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,38 @@
+# This workflow triggers on a published release event.
+# Requires the following secrets:
+# - PAKETO_BOT_GITHUB_TOKEN -> a token with permissions to send the dispatch to the language family repo
+
+name: Send Release Dispatch
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  dispatch:
+    runs-on: ubuntu-latest
+    name: Send Dispatch
+    steps:
+
+    - name: Parse ID and Version
+      id: dependency
+      run: |
+        echo "::set-output name=id::$(jq -r .repository.full_name ${{ github.event_path }})"
+        echo "::set-output name=version::$(jq -r .release.tag_name ${{ github.event_path }} | sed 's/^v//')"
+
+    # Generic repository dispatch sender.
+    - name: Send Repository Dispatch
+      uses: paketo-buildpacks/github-config/actions/dispatch@master
+      with:
+        repos: paketo-community/ruby # comma-separated list of repos receiving the dispatch
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        event: dependency-update
+        payload: |
+          {
+            "strategy": "replace",
+            "dependency": {
+              "id": "${{ steps.dependency.outputs.id }}",
+              "version": "${{ steps.dependency.outputs.version }}"
+            }
+          }


### PR DESCRIPTION
The `paketo-community/ruby` buildpack has recently started consuming the Procfile buildpack as a dependency. We will want to pull in the latest versions of the Procfile buildpack when they are released. For many of the other Paketo buildpacks, we have a GitHub Actions workflow that sends a repository dispatch event to a set of repos when a release is published (in this case, it is only `paketo-community/ruby`). That event contains the repository name and version so that the recipient can update its internal references.

We'd like to have that same workflow for the Procfile buildpack so that we don't have to maintain some sort of external monitoring of the releases. Would it be possible to include this workflow here?