### PR TITLE
Script-Style Process Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This buildpack will participate if all the following conditions are met
 The buildpack will do the following:
 
 * Contribute the process types from `Procfile` to the image.
+  * If the application's stack is `io.paketo.stacks.tiny` the contents of the `Procfile` must be single commands with arguments (no inline environment variable declarations, environment variable references, or joined processes) and will be shellparsed to run in `direct` mode.
+  * If the application's stack is not `io.paketo.stacks.tiny` the contents of `Procfile` have no limiataions and will be executed in a shell as-is.
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This buildpack will participate if all the following conditions are met
 The buildpack will do the following:
 
 * Contribute the process types from `Procfile` to the image.
-  * If the application's stack is `io.paketo.stacks.tiny` the contents of the `Procfile` must be single commands with arguments (no inline environment variable declarations, environment variable references, or joined processes) and will be shellparsed to run in `direct` mode.
-  * If the application's stack is not `io.paketo.stacks.tiny` the contents of `Procfile` have no limiataions and will be executed in a shell as-is.
+  * If the application's stack is `io.paketo.stacks.tiny` the contents of the `Procfile` must be single command with zero or more space delimited arguments. Argument values containing whitespace should be quoted. The resulting process will be executed directly and will not be parsed by the shell.
+  * If the application's stack is not `io.paketo.stacks.tiny` the contents of `Procfile` will be executed as a shell script.
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/procfile/build.go
+++ b/procfile/build.go
@@ -43,19 +43,19 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	for k, v := range e.Metadata {
-		s, err := shellwords.Parse(v.(string))
-		if err != nil {
-			return libcnb.BuildResult{}, fmt.Errorf("unable to parse %s\n%w", s, err)
-		}
-
-		process := libcnb.Process{
-			Type:      k,
-			Command:   s[0],
-			Arguments: s[1:],
-		}
+		process := libcnb.Process{Type: k}
 
 		if context.StackID == libpak.TinyStackID {
+			s, err := shellwords.Parse(v.(string))
+			if err != nil {
+				return libcnb.BuildResult{}, fmt.Errorf("unable to parse %s\n%w", s, err)
+			}
+
+			process.Command = s[0]
+			process.Arguments = s[1:]
 			process.Direct = true
+		} else {
+			process.Command = v.(string)
 		}
 
 		result.Processes = append(result.Processes, process)

--- a/procfile/build_test.go
+++ b/procfile/build_test.go
@@ -57,14 +57,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			libcnb.Process{
 				Type:    "test-type-1",
 				Command: "test-command-1",
-				Arguments: []string{},
-				Direct:  false,
 			},
 			libcnb.Process{
 				Type:    "test-type-2",
-				Command: "test-command-2",
-				Arguments: []string{"argument"},
-				Direct:  false,
+				Command: "test-command-2 argument",
 			},
 		)
 


### PR DESCRIPTION
Previously, whenever a Procfile was parsed and turned into collection of process types, the arguments were always shell-parsed.  It turns out that Procfiles commonly have inline environment variables (FOO=bar ./my-app), and joined commands (./my-app-1 && ./my-app-2).  None of these things shell-parse well.

This change update the behavior so that the command is shell-parsed if it's going onto `tiny` (a shell-less stack), but will leave it as "script-style"command for all stacks with a shell.
