### PR TITLE
Buildpack metadata updates

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api = "0.5"
+api = "0.6"
 
 [buildpack]
 id       = "paketo-buildpacks/procfile"
 name     = "Paketo Procfile Buildpack"
 version  = "{{.version}}"
 homepage = "https://github.com/paketo-buildpacks/procfile"
+description = "A buildpack for translating a Procfile into Process Types"
+keywords    = ["procfile", "command"]
+
+[[buildpack.licenses]]
+type = "Apache-2.0"
+uri  = "https://github.com/paketo-buildpacks/procfile/blob/main/LICENSE"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"

--- a/procfile/build.go
+++ b/procfile/build.go
@@ -19,6 +19,7 @@ package procfile
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/mattn/go-shellwords"
@@ -43,7 +44,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	for k, v := range e.Metadata {
-		process := libcnb.Process{Type: k}
+		process := libcnb.Process{Type: k, Default: strings.ToLower(k) == "web"}
 
 		if context.StackID == libpak.TinyStackID {
 			s, err := shellwords.Parse(v.(string))
@@ -59,6 +60,17 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		}
 
 		result.Processes = append(result.Processes, process)
+	}
+
+	defaultSet := false
+	for _, process := range result.Processes {
+		if process.Default {
+			defaultSet = true
+			break
+		}
+	}
+	if !defaultSet && len(result.Processes) > 0 {
+		result.Processes[0].Default = true
 	}
 
 	sort.Slice(result.Processes, func(i int, j int) bool {

--- a/procfile/build_test.go
+++ b/procfile/build_test.go
@@ -39,7 +39,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(build.Build(ctx)).To(Equal(libcnb.BuildResult{}))
 	})
 
-	it("adds metadata to result", func() {
+	it("adds metadata to result, marks first process as default", func() {
 		ctx.Plan = libcnb.BuildpackPlan{
 			Entries: []libcnb.BuildpackPlanEntry{
 				{
@@ -57,10 +57,40 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			libcnb.Process{
 				Type:    "test-type-1",
 				Command: "test-command-1",
+				Default: true,
 			},
 			libcnb.Process{
 				Type:    "test-type-2",
 				Command: "test-command-2 argument",
+			},
+		)
+
+		Expect(build.Build(ctx)).To(Equal(result))
+	})
+
+	it("adds metadata to result, marks web process as default", func() {
+		ctx.Plan = libcnb.BuildpackPlan{
+			Entries: []libcnb.BuildpackPlanEntry{
+				{
+					Name: "procfile",
+					Metadata: map[string]interface{}{
+						"test-type-1": "test-command-1",
+						"web":         "test-command-2 argument",
+					},
+				},
+			},
+		}
+
+		result := libcnb.NewBuildResult()
+		result.Processes = append(result.Processes,
+			libcnb.Process{
+				Type:    "test-type-1",
+				Command: "test-command-1",
+			},
+			libcnb.Process{
+				Type:    "web",
+				Command: "test-command-2 argument",
+				Default: true,
 			},
 		)
 
@@ -92,6 +122,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Command:   "test-command-1",
 					Arguments: []string{},
 					Direct:    true,
+					Default:   true,
 				},
 				libcnb.Process{
 					Type:      "test-type-2",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,10 +5,13 @@ set -euo pipefail
 GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/procfile/cmd/main
 GOOS="windows" GOARCH="amd64" go build -ldflags='-s -w' -o bin/main.exe github.com/paketo-buildpacks/procfile/cmd/main
 
-strip bin/main
-upx -q -9 bin/main
-strip bin/main.exe
-upx -q -9 bin/main.exe
+if [ "${STRIP:-false}" != "false" ]; then
+  strip bin/main bin/main.exe
+fi
+
+if [ "${COMPRESS:-false}" != "false" ]; then
+  upx -q -9 bin/main bin/main.exe
+fi
 
 ln -fs main bin/build
 ln -fs main bin/detect


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Bump the lifecycle to 0.6, add description, keywords and license metadata and make running 'upx' optional, default off in build script. 

Lifecycle 0.6 allows a buildpack to set the default process type. Procfile will set the default to be a process named 'web' or the first process in the list.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
