### PR TITLE
Added support for creating Procfile from a binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,27 @@
 The Procfile Buildpack is a Cloud Native Buildpack that turns the contents of a Procfile into process types.
 
 ## Behavior
-This buildpack will participate if all the following conditions are met
+This buildpack will participate if one or all of the following conditions are met:
 
 * The application contains a `Procfile`
+* A Binding exists with type `Procfile` and secret containing a `Procfile`
 
 The buildpack will do the following:
 
-* Contribute the process types from `Procfile` to the image.
+* Contribute the process types from one or both `Procfile` files to the image.
+  * If process types are identified from both Binding _and_ file, the contents are merged into a single `Procfile`. Commands from the Binding take precedence if there are duplicate types.
   * If the application's stack is `io.paketo.stacks.tiny` the contents of the `Procfile` must be single command with zero or more space delimited arguments. Argument values containing whitespace should be quoted. The resulting process will be executed directly and will not be parsed by the shell.
   * If the application's stack is not `io.paketo.stacks.tiny` the contents of `Procfile` will be executed as a shell script.
+
+## Bindings
+
+The buildpack optionally accepts the following bindings:
+
+|Key                   | Value   | Description
+|----------------------|---------|------------
+|`Procfile` |List of`<process-type>: <command>` entries | The entries from this Binding will be merged with those from the application's `Procfile`, if both are present. The commands from this Binding take precedence over the application's `Procfile` if there are duplicate process-types.
+
+
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/procfile/detect.go
+++ b/procfile/detect.go
@@ -23,7 +23,8 @@ import (
 type Detect struct{}
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
-	p, err := NewProcfileFromPath(context.Application.Path)
+	// Create Procfile from source path or binding, if both exist, merge into one. The binding takes precedence on duplicate name/command pairs.
+	p, err := NewProcfileFromPathOrBinding(context.Application.Path, context.Platform.Bindings)
 	if err != nil {
 		return libcnb.DetectResult{}, err
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Resolves #45  

This PR adds support for creation of a Procfile from a Binding.

* The binding should have Type `Procfile`. 
* If a Procfile is found as a file with the application, **and** in a Binding, it attempts to merge the two into a single Procfile. 
* If there are duplicate name/command pairs, the Binding command takes precedence.

## Use Cases
See issue #45 

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
