### PR TITLE
Makes the wildcard id the only one

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -32,13 +32,4 @@ api = "0.7"
   pre-package = "scripts/build.sh"
 
 [[stacks]]
-  id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-  id = "io.paketo.stacks.tiny"
-
-[[stacks]]
   id = "*"
-
-[[stacks]]
-  id = "io.buildpacks.stacks.windows.servercore"


### PR DESCRIPTION
The wildcard id is the only id that is needed

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
