### PR TITLE
Bump Buildpack API version to 0.8

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api = "0.7"
+api = "0.8"
 
 [buildpack]
   description = "A buildpack for translating a Procfile into Process Types"


### PR DESCRIPTION
## Summary

Bump to Buildpack API version 0.8
Looking at the [release notes](https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8) I could not find anything that would be relevant for this Buildpack, so simply bumping the version in the `buildpack.toml` should do the trick.

## Use Cases

Prepare for update to 0.9, which actually has some changes relevant for this buildpack (removal of `direct=false`)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
