### PR TITLE
Add detection logging messages at info level

### DIFF
--- a/procfile/detect.go
+++ b/procfile/detect.go
@@ -18,11 +18,14 @@ package procfile
 
 import (
 	"github.com/buildpacks/libcnb"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"os"
 )
 
 type Detect struct{}
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
+	l := bard.NewLogger(os.Stdout)
 	// Create Procfile from source path or binding, if both exist, merge into one. The binding takes precedence on duplicate name/command pairs.
 	p, err := NewProcfileFromPathOrBinding(context.Application.Path, context.Platform.Bindings)
 	if err != nil {
@@ -30,6 +33,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 	}
 
 	if len(p) == 0 {
+		l.Logger.Info("SKIPPED: No procfile found from either source path or binding.")
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

*Log messages were checked during testing*
```
=== RUN   TestUnit/procfile/Detect/fails_without_Procfile
SKIPPED: No procfile found from either source path or binding.
```

## Summary
This PR adds additional logging when Detect returns false for this buildpack. This is to provide more information about why the detection failed for this buildpack when verbose/debug logging is enabled. 

As of lifecycle v1.16.0, if the detect phase fails as a whole, log messages are printed at info level by default, without the need for the verbose flag.

## Use Cases
A `pack build` command with the `--verbose` flag set will show these log statement if detection fails. If Detect succeeds, the output is not shown unless `--verbose` is set.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).