### PR TITLE
Add support for BP_PROCFILE_DEFAULT_PROCESS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ This buildpack will participate if one or all of the following conditions are me
 
 * The application contains a `Procfile`
 * A Binding exists with type `Procfile` and secret containing a `Procfile`
+* The `BP_PROCFILE_DEFAULT_PROCESS` environment variable is set to a non-empty value
 
 The buildpack will do the following:
 
+* When `BP_PROCFILE_DEFAULT_PROCESS` is set, it will contribute the `web` process type to the image.
 * Contribute the process types from one or both `Procfile` files to the image.
   * If process types are identified from both Binding _and_ file, the contents are merged into a single `Procfile`. Commands from the Binding take precedence if there are duplicate types.
+  * If process types are identified from environment _and_ Binding _or_ file, the contents are merged into a single `Procfile`. Commands from Binding or file take precedence if there are duplicate types, with Binding taking precedence over file.
   * If the application's stack is `io.paketo.stacks.tiny` the contents of the `Procfile` must be single command with zero or more space delimited arguments. Argument values containing whitespace should be quoted. The resulting process will be executed directly and will not be parsed by the shell.
   * If the application's stack is not `io.paketo.stacks.tiny` the contents of `Procfile` will be executed as a shell script.
 

--- a/procfile/detect.go
+++ b/procfile/detect.go
@@ -17,9 +17,10 @@
 package procfile
 
 import (
+	"os"
+
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/libpak/bard"
-	"os"
 )
 
 type Detect struct{}
@@ -27,13 +28,13 @@ type Detect struct{}
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
 	l := bard.NewLogger(os.Stdout)
 	// Create Procfile from source path or binding, if both exist, merge into one. The binding takes precedence on duplicate name/command pairs.
-	p, err := NewProcfileFromPathOrBinding(context.Application.Path, context.Platform.Bindings)
+	p, err := NewProcfileFromEnvironmentOrPathOrBinding(context.Application.Path, context.Platform.Bindings)
 	if err != nil {
 		return libcnb.DetectResult{}, err
 	}
 
 	if len(p) == 0 {
-		l.Logger.Info("SKIPPED: No procfile found from either source path or binding.")
+		l.Logger.Info("SKIPPED: No procfile found from environment, source path, or binding.")
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 

--- a/procfile/detect_test.go
+++ b/procfile/detect_test.go
@@ -17,7 +17,6 @@
 package procfile_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,10 +37,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
-		ctx.Application.Path, err = ioutil.TempDir("", "procfile")
-		Expect(err).NotTo(HaveOccurred())
+		ctx.Application.Path = t.TempDir()
 	})
 
 	it.After(func() {
@@ -53,20 +49,20 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("fails with empty Procfile", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Procfile"), []byte(""), 0644))
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "Procfile"), []byte(""), 0644))
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
 	})
 
 	it("fails with empty Procfile and empty BP_PROCFILE_DEFAULT_PROCESS", func() {
 		t.Setenv("BP_PROCFILE_DEFAULT_PROCESS", "")
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Procfile"), []byte(""), 0644))
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "Procfile"), []byte(""), 0644))
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
 	})
 
 	it("passes with Procfile", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Procfile"), []byte(`test-type-1: test-command-1
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "Procfile"), []byte(`test-type-1: test-command-1
 test-type-2: test-command-2`), 0644))
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{

--- a/procfile/detect_test.go
+++ b/procfile/detect_test.go
@@ -48,11 +48,18 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(ctx.Application.Path)).To(Succeed())
 	})
 
-	it("fails without Procfile", func() {
+	it("fails without Procfile or BP_PROCFILE_DEFAULT_PROCESS", func() {
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
 	})
 
 	it("fails with empty Procfile", func() {
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Procfile"), []byte(""), 0644))
+
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
+	})
+
+	it("fails with empty Procfile and empty BP_PROCFILE_DEFAULT_PROCESS", func() {
+		t.Setenv("BP_PROCFILE_DEFAULT_PROCESS", "")
 		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "Procfile"), []byte(""), 0644))
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
@@ -73,6 +80,26 @@ test-type-2: test-command-2`), 0644))
 						{Name: "procfile", Metadata: procfile.Procfile{
 							"test-type-1": "test-command-1",
 							"test-type-2": "test-command-2",
+						}},
+					},
+				},
+			},
+		}))
+	})
+
+	it("passes with BP_PROCFILE_DEFAULT_PROCESS", func() {
+		t.Setenv("BP_PROCFILE_DEFAULT_PROCESS", "test-command-1")
+
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+			Pass: true,
+			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "procfile"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "procfile", Metadata: procfile.Procfile{
+							"web": "test-command-1",
 						}},
 					},
 				},


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change adds support to allow users to specify a default process by setting the `BP_PROCFILE_DEFAULT_PROCESS` environment variable. When environment variable `BP_PROCFILE_DEFAULT_PROCESS` is set to a non-empty value, the value will be set as the `web` process type, which is the default process.

`Procfile` file and binding take precedence over the environment variable, and a message will printed if the environment variable and either file type is also used. 

## Use Cases
There are times when a user needs to specify a default process for an application, but they do not necessarily want to add a Procfile to their application source code. The paketo python buildpack is a good example where the user needs to specify a Procfile, otherwise the default process will be the python shell (REPL).

Since most users will likely only need to specify one process type, the default process, it should be configurable through an environment variable.

<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
