### PR TITLE
Document that binding needs also the type Procfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ The `BP_DIRECT_PROCESS` environment variable can be used to opt-in in starting p
 
 The buildpack optionally accepts the following bindings:
 
-|Key                   | Value   | Description
-|----------------------|---------|------------
-|`Procfile` |List of`<process-type>: <command>` entries | The entries from this Binding will be merged with those from the application's `Procfile`, if both are present. The commands from this Binding take precedence over the application's `Procfile` if there are duplicate process-types.
+|Key                   | Type | Value   | Description
+|----------------------|------|---------|------------
+|`Procfile` |`Procfile` |List of`<process-type>: <command>` entries | The entries from this Binding will be merged with those from the application's `Procfile`, if both are present. The commands from this Binding take precedence over the application's `Procfile` if there are duplicate process-types.
 
 
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
It is only documented that the binding needs to have the `key` `Procfile`, but in fact it also needs the `type` to be `Procfile`.

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
