### PR TITLE
Allow arguments when using BP_DIRECT_PROCESS

### DIFF
--- a/procfile/build.go
+++ b/procfile/build.go
@@ -47,7 +47,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	for k, v := range e.Metadata {
 		process := libcnb.Process{Type: k}
 
-		if (context.StackID == libpak.BionicTinyStackID) || (context.StackID == libpak.JammyTinyStackID) {
+		if (context.StackID == libpak.BionicTinyStackID) || (context.StackID == libpak.JammyTinyStackID) || sherpa.ResolveBool("BP_DIRECT_PROCESS") {
 			s, err := shellwords.Parse(v.(string))
 			if err != nil {
 				return libcnb.BuildResult{}, fmt.Errorf("unable to parse %s\n%w", s, err)
@@ -58,7 +58,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			process.Direct = true
 		} else {
 			process.Command = v.(string)
-			process.Direct = sherpa.ResolveBool("BP_DIRECT_PROCESS")
+			process.Direct = false
 		}
 
 		result.Processes = append(result.Processes, process)

--- a/procfile/build_test.go
+++ b/procfile/build_test.go
@@ -78,7 +78,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					{
 						Name: "procfile",
 						Metadata: map[string]interface{}{
-							"test-type": "test-command",
+							"test-type": "test-command arg",
 						},
 					},
 				},
@@ -87,9 +87,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result := libcnb.NewBuildResult()
 			result.Processes = append(result.Processes,
 				libcnb.Process{
-					Type:    "test-type",
-					Command: "test-command",
-					Direct:  true,
+					Type:      "test-type",
+					Command:   "test-command",
+					Arguments: []string{"arg"},
+					Direct:    true,
 				},
 			)
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
When using `BP_DIRECT_PROCESS` because you do not have a `bash`, the buildpack must tokenize the command string in case on arguments.

## Summary
<!-- A short explanation of the proposed change -->
In this case, do the same as for the `tiny` stacks.

## Use Cases
<!-- An explanation of the use cases your change enables -->
In case the process you wanna start has some arguments.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
